### PR TITLE
bug fix + shortcuts to editor

### DIFF
--- a/src/dialogs/editor.py
+++ b/src/dialogs/editor.py
@@ -685,7 +685,7 @@ class CreateTab(QWidget):
 
     def on_remove_bold_clicked(self):
         html = self.text.toHtml()
-        html = remove_all_bold_formatting(html)
+        html = utility.text.remove_all_bold_formatting(html)
         self.text.setHtml(html)
 
     def on_bullet_list_clicked(self):

--- a/src/dialogs/editor.py
+++ b/src/dialogs/editor.py
@@ -476,6 +476,7 @@ class CreateTab(QWidget):
         bold.setFont(f)
         bold.setCheckable(True)
         bold.triggered.connect(self.on_bold_clicked)
+        bold.setShortcut(QKeySequence("Ctrl+b"))
 
         italic = self.tb.addAction("i")
         italic.setCheckable(True)
@@ -483,6 +484,7 @@ class CreateTab(QWidget):
         f = italic.font()
         f.setItalic(True)
         italic.setFont(f)
+        italic.setShortcut(QKeySequence("Ctrl+i"))
 
         underline = self.tb.addAction("u")
         underline.setCheckable(True)
@@ -490,6 +492,7 @@ class CreateTab(QWidget):
         f = underline.font()
         f.setUnderline(True)
         underline.setFont(f)
+        underline.setShortcut(QKeySequence("Ctrl+u"))
 
         strike = self.tb.addAction("s")
         strike.setCheckable(True)


### PR DESCRIPTION
at the moment the command "Remove all bold formatting" throws this error:

```python
addons21/1781298089/src/dialogs/editor.py", line 688, in on_remove_bold_clicked
    html = remove_all_bold_formatting(html)
<class 'NameError'>: name 'remove_all_bold_formatting' is not defined
```

In the other commit I added some minimal/basic shortcuts I liked. But maybe you want to have this user configurable.

Thanks for this great extension. 

P.S.: I've finally uploaded the add-on I mentioned in December ([Cut/Copy from editor to new note or add window (with scheduling)](https://ankiweb.net/shared/info/1095648795)) to Ankiweb.

