### PR TITLE
hotfix: youtube https url opening in browser

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -98,6 +98,8 @@ class SiacNote(Printable):
         return self.source is not None and self.source.strip().lower().endswith(".pdf")
 
     def is_file(self) -> bool:
+        if self.is_yt():
+            return False
         return self.source is not None and re.match("^([\S]+)://", self.source.strip().lower())
 
     def is_feed(self) -> bool:


### PR DESCRIPTION
is_file didn't check whether or not it was a youtube link, thus opening 
such links in the standard browser. Fixed by checking for youtube link 
syntax in is_file logic. Downside: youtube links can not be watched 
externally, maybe workaround later if demand is voiced.