### PR TITLE
Fix: 'Collection"'object has no attribute '_startTime'

### DIFF
--- a/src/command_parsing.py
+++ b/src/command_parsing.py
@@ -629,7 +629,7 @@ def expanded_on_bridge_cmd(handled: Tuple[bool, Any], cmd: str, self: Any) -> Tu
         stamp = set_stamp()
         notes = get_random(index.limit, index.pinned)
         UI.print_search_results(["SIAC notes", "Random"],  notes, stamp)
-    
+
     elif cmd == "siac-r-user-note-random-pdf":
         stamp = set_stamp()
         notes = get_random_pdf_notes(index.limit, index.pinned)
@@ -1211,6 +1211,7 @@ def expanded_on_bridge_cmd(handled: Tuple[bool, Any], cmd: str, self: Any) -> Tu
                 due_today   = mw.col.findCards("(is:due or is:new or (prop:due=1 and is:review)) and (%s)" % " or ".join([f"nid:{nid}" for nid in last_linked]))
             success     = create_filtered_deck(due_today)
             if success:
+                mw.col.startTimebox()
                 mw.moveToState("review")
                 mw.activateWindow()
                 # workaround, as activateWindow doesn't seem to bring the main window on top on OSX
@@ -1859,7 +1860,7 @@ def get_index_info():
 
     issues = UI.known_issues()
 
-    if issues:  
+    if issues:
         html += "<br/><br/><b>Known Issues:</b><hr>"
         for ix, i in enumerate(issues):
             html += f"<br>{ix + 1}. {i}"


### PR DESCRIPTION
A user on Discord reported this error to me:

```An error occurred. Please start Anki while holding down the shift key, which will temporarily disable the add-ons you have installed.
If the issue only occurs when add-ons are enabled, please use the Tools > Add-ons menu item to disable some add-ons and restart Anki, repeating until you discover the add-on that is causing the problem.
When you've discovered the add-on that is causing the problem, please report the issue on the add-on support site.
Debug info:
Anki 2.1.40 (cf446733) Python 3.8.6 Qt 5.14.2 PyQt 5.14.2
Platform: Mac 10.13.6
Flags: frz=True ao=True sv=2
Add-ons, last update check: 2021-02-16 09:34:44
Add-ons possibly involved: ⁨Searching PDF Reading  Note-Taking in Add Dialog⁩

Caught exception:
Traceback (most recent call last):
  File "aqt/webview.py", line 35, in cmd
  File "aqt/webview.py", line 124, in _onCmd
  File "aqt/webview.py", line 563, in _onBridgeCmd
  File "aqt/hooks_gen.py", line 3119, in __call__
  File "/Users/***/Library/Application Support/Anki2/addons21/1781298089/src/command_parsing.py", line 1214, in expanded_on_bridge_cmd
    mw.moveToState("review")
  File "aqt/main.py", line 646, in moveToState
  File "aqt/main.py", line 668, in _reviewState
  File "aqt/reviewer.py", line 72, in show
  File "aqt/reviewer.py", line 92, in nextCard
  File "anki/collection.py", line 542, in timeboxReached
AttributeError: 'Collection' object has no attribute '_startTime'
```

This can occur if a user has not started the collection timebox yet (by reviewing a few cards), but opens a PDF and reviews any unseen cards (filtered deck "PDF Reviews"). Bug fixed by starting the timebox before moving to "review" state: `mw.col.startTimebox()`